### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -95,7 +95,7 @@ sudo bless --folder /Volumes/USBstick/ --file /Volumes/USBstick/System/Library/C
 * [MacMini1,1 3A102](http://download.info.apple.com/Apple_Hardware_Test/018-2342-A.dmg)
 * [MacMini2,1    Mac-F4208EAA](http://download.info.apple.com/Apple_Hardware_Test/018-2886-A.dmg)
 * [MacMini3,1    Mac-F22C86C8](http://download.info.apple.com/Apple_Hardware_Test/022-4292-A.dmg)
-* [MacMini4,1    Mac-F2208EC8](http://download.info.apple.com/Apple_Hardware_Test/022-4739-A.dmg)
+* [MacMini4,1    Mac-F2208EC8 (Server)](http://download.info.apple.com/Apple_Hardware_Test/022-4739-A.dmg)
 * [MacMini4,1    Mac-F2208EC8](http://download.info.apple.com/Apple_Hardware_Test/022-4706-A.dmg)
 * [MacMini5,1    Mac-8ED6AF5B48C039E1](http://download.info.apple.com/Apple_Hardware_Test/022-5207-A.dmg)
 * [MacMini5,2    Mac-4BC72D62AD45599E](http://download.info.apple.com/Apple_Hardware_Test/022-5207-A.dmg)


### PR DESCRIPTION
Indicate that one of the MacMini4,1 images is for the server model. This can be extremely handy as the shortcut for starting diagnostics on Mac mini 2010 Server models does not work and only shows an error telling the machine is not supported by AHT.
The image has been verified and tested on real Mac mini 2010 Server hardware